### PR TITLE
docs: restore MarkiNote integration overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
     <a href="#tools">Tools</a> ·
     <a href="#security">安全</a> ·
     <a href="#stars">Star 趋势</a> ·
+    <a href="#finnote">FinNote 联动</a> ·
     <a href="README_EN.md">English</a>
   </p>
 </div>
@@ -276,6 +277,25 @@ npm run start:http    # http://127.0.0.1:3000/mcp
 
 如果 FinanceMCP 对你有帮助，欢迎点一个 ⭐。趋势图由仓库自己的 GitHub Actions 每周一自动更新，也支持手动刷新；使用仓库临时 `GITHUB_TOKEN`，不依赖第三方 Star 抓取服务或长期凭证。
 
+<a id="finnote"></a>
+
+## 🔗 项目联动：FinNote 智能金融文档系统
+
+FinanceMCP 已与 [MarkiNote](https://github.com/wink-wink-wink555/MarkiNote) 联动，共同构成 **FinNote 智能金融文档系统**，面向金融研究、AI 辅助分析和长期知识沉淀。该项目曾参加上海市大学生计算机应用能力大赛并获得二等奖。
+
+- **FinanceMCP：金融数据与工具服务层。** 通过 19 个标准化 MCP Tools，为 AI Agent 提供股票、基金、债券、宏观经济、财经新闻、技术指标和多市场金融数据。
+- **MarkiNote：AI Agent 文档与知识管理应用层。** 接收并组织自然语言任务，在可编辑的 Markdown 工作区中呈现金融数据和模型分析，并将分析结果沉淀为可管理、可追踪、可复用的文档资产。
+
+两者通过 HTTP / MCP 服务链路协作：
+
+```text
+自然语言请求 → AI Agent 理解任务 → 调用 FinanceMCP → 获取金融数据 → AI 辅助分析 → 生成并保存 Markdown 文档 → 持续编辑与知识管理
+```
+
+因此，FinanceMCP 不仅能独立服务 Claude、Cursor 等 MCP 客户端，也能作为 FinNote 的实时金融数据底座；MarkiNote 则把数据调用、模型分析和长期文档管理整合进同一个研究工作区。
+
+🌐 **在线体验：[https://finvestai.top/](https://finvestai.top/)**
+
 ## 🤝 生态与贡献
 
 <p align="center">
@@ -284,8 +304,6 @@ npm run start:http    # http://127.0.0.1:3000/mcp
   </a>
 </p>
 
-- FinanceMCP 可作为 [FinNote / MarkiNote](https://github.com/wink-wink-wink555/MarkiNote) 的金融数据后端。
-- 在线体验：[finvestai.top](https://finvestai.top/)
 - MCP 生态收录：[Glama](https://glama.ai/mcp/servers/@guangxiangdebizi/my-mcp-server) · [Smithery](https://smithery.ai/servers/@guangxiangdebizi/FinanceMCP) · [MCP Toplist](https://mcptoplist.com/server/pulsemcp%2Fguangxiangdebizi-finance-market-data)
 - 视频教程：[FinanceMCP 完整使用指南](https://www.bilibili.com/video/BV1qeNnzEEQi/)
 - Bug 与功能建议：[GitHub Issues](https://github.com/guangxiangdebizi/FinanceMCP/issues)

--- a/README_EN.md
+++ b/README_EN.md
@@ -29,6 +29,7 @@
     <a href="#tools">Tools</a> ·
     <a href="#security">Security</a> ·
     <a href="#stars">Star history</a> ·
+    <a href="#finnote">FinNote integration</a> ·
     <a href="README.md">中文</a>
   </p>
 </div>
@@ -276,6 +277,25 @@ npm run start:http    # http://127.0.0.1:3000/mcp
 
 If FinanceMCP is useful to you, consider leaving a ⭐. The repository's own GitHub Actions refreshes this chart every Monday (or on demand) with its temporary `GITHUB_TOKEN`, without third-party stargazer scraping or long-lived credentials.
 
+<a id="finnote"></a>
+
+## 🔗 Project integration: FinNote intelligent financial document system
+
+FinanceMCP integrates with [MarkiNote](https://github.com/wink-wink-wink555/MarkiNote) to form **FinNote**, an intelligent financial document system for financial research, AI-assisted analysis, and long-term knowledge preservation. The project received a Second Prize in the Shanghai Collegiate Computer Application Ability Competition.
+
+- **FinanceMCP: financial data and tool service layer.** Its 19 standardized MCP tools give AI agents access to stocks, funds, bonds, macroeconomic data, financial news, technical indicators, and multi-market financial data.
+- **MarkiNote: AI-agent document and knowledge-management layer.** It organizes natural-language tasks, presents financial data and model-generated analysis in an editable Markdown workspace, and preserves the results as manageable, traceable, and reusable document assets.
+
+The two projects collaborate through an HTTP / MCP service workflow:
+
+```text
+Natural-language request → AI Agent task understanding → FinanceMCP tool invocation → Financial data retrieval → AI-assisted analysis → Markdown document generation and preservation → Continuous editing and knowledge management
+```
+
+FinanceMCP can therefore run independently for MCP clients such as Claude and Cursor or provide FinNote's real-time financial data foundation, while MarkiNote brings data retrieval, model analysis, and long-term document management into one research workspace.
+
+🌐 **Live demo: [https://finvestai.top/](https://finvestai.top/)**
+
 ## 🤝 Ecosystem and contributions
 
 <p align="center">
@@ -284,8 +304,6 @@ If FinanceMCP is useful to you, consider leaving a ⭐. The repository's own Git
   </a>
 </p>
 
-- FinanceMCP can serve as the financial-data backend for [FinNote / MarkiNote](https://github.com/wink-wink-wink555/MarkiNote).
-- Live endpoint: [finvestai.top](https://finvestai.top/)
 - MCP ecosystem listings: [Glama](https://glama.ai/mcp/servers/@guangxiangdebizi/my-mcp-server) · [Smithery](https://smithery.ai/servers/@guangxiangdebizi/FinanceMCP) · [MCP Toplist](https://mcptoplist.com/server/pulsemcp%2Fguangxiangdebizi-finance-market-data)
 - Video guide: [Complete FinanceMCP tutorial](https://www.bilibili.com/video/BV1qeNnzEEQi/)
 - Bugs and feature requests: [GitHub Issues](https://github.com/guangxiangdebizi/FinanceMCP/issues)


### PR DESCRIPTION
## What changed

- restore a dedicated bilingual FinNote / MarkiNote integration section in `README.md` and `README_EN.md`
- explain the responsibilities of FinanceMCP and MarkiNote in the shared architecture
- document the HTTP / MCP workflow from a natural-language request to a reusable Markdown research asset
- add navigation links and keep the live demo visible

## Why

The earlier README cleanup reduced the FinNote / MarkiNote integration explanation to a single ecosystem bullet, removing the architecture and workflow context. This restores that project relationship in a clear, discoverable form aligned with the current MarkiNote documentation.

## Impact

Documentation only. No runtime behavior, configuration, MCP tools, dependencies, or release artifacts change.

## Validation

- `git diff --check`
- verified the MarkiNote repository and current integration wording through the GitHub API
- verified `https://finvestai.top/` returns HTTP 200
- confirmed the commit contains only `README.md` and `README_EN.md`