### PR TITLE
feat: scope MCP tool discovery by credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 </div>
 
 > [!IMPORTANT]
-> **v4.9.0** 在不新增 Tool、也不修改现有 Tool 参数的前提下，引入请求级 Qveris 数据源路由、自动降级和结果来源标注。现有客户端可以无缝升级。
+> **v4.10.0** 在保留现有 19 个 Tool 名称与参数的前提下，新增按请求凭证裁剪 `tools/list` 的能力，并保留 v4.9.0 的 Qveris 路由、自动降级和来源标注。
 
 > [!NOTE]
 > 需要在 Trae、Cursor、Claude Code 和 Codex 之间共享模型 Prompt/KV-cache 路由及对话 lineage 时，可选启动独立的 [`finance-cache-gateway`](./docs/cache-gateway.md)。它使用单独的进程、端口和配置；不修改现有 MCP Tool、stdio 或 `/mcp` 接口，不启用时现有用法完全不变。
@@ -118,6 +118,10 @@ tushare,qveris,binance
 
 > [!NOTE]
 > Qveris 是可选扩展。未提供 `X-Qveris-Api-Key` / `QVERIS_API_KEY` 时不会调用 Qveris，也不会消耗 credits。接口契约参见 [Qveris REST API](https://qveris.ai/docs/rest-api)。
+
+### 按凭证动态显示 Tools
+
+`tools/list` 会根据当前 MCP 请求实际携带的凭证裁剪工具目录：只传 Qveris Key 时只展示 Qveris adapter 覆盖的现有 Tools，只传 Tushare Token 时只展示 Tushare 覆盖的 Tools；同时传入两者时展示两者的并集。没有凭证时仅展示公共数据源与本地工具。`tools/call` 也执行相同校验，避免 AI 调用到当前请求无法使用的数据源。
 
 <a id="providers"></a>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -34,7 +34,7 @@
 </div>
 
 > [!IMPORTANT]
-> **v4.9.0** adds request-scoped Qveris routing, automatic fallback, and source attribution without adding tools or changing existing tool parameters. Existing clients can upgrade without schema changes.
+> **v4.10.0** adds credential-scoped `tools/list` discovery while preserving the existing 19 tool names and parameters, plus the v4.9.0 Qveris routing, fallback, and source attribution behavior.
 
 > [!NOTE]
 > To share model prompt/KV-cache routing and conversation lineage across Trae, Cursor, Claude Code, and Codex, optionally run the standalone [`finance-cache-gateway`](./docs/cache-gateway.md). It uses a separate process, port, and configuration; existing MCP tools, stdio, and `/mcp` behavior remain unchanged when it is not enabled.
@@ -118,6 +118,14 @@ Existing tool output...
 
 > [!NOTE]
 > Qveris is optional. FinanceMCP does not call Qveris or consume credits unless `X-Qveris-Api-Key` / `QVERIS_API_KEY` is present. See the [Qveris REST API](https://qveris.ai/docs/rest-api).
+
+### Credential-scoped tool discovery
+
+`tools/list` filters the MCP catalog by credentials on the current request. A
+Qveris-only request exposes only tools covered by the Qveris adapter; a
+Tushare-only request exposes Tushare-backed tools; both credentials expose the
+union. With no credential, only public and local tools are listed. `tools/call`
+enforces the same scope.
 
 <a id="providers"></a>
 

--- a/docs/tool-availability.md
+++ b/docs/tool-availability.md
@@ -1,0 +1,31 @@
+# Credential-Scoped MCP Tools
+
+FinanceMCP advertises only tools backed by sources available to the current
+MCP request. The same source check runs before `tools/call`, so a client cannot
+bypass discovery by submitting a hidden tool name directly.
+
+## Source policy
+
+- `tushare`: native market, macro, company, fund, flow, and futures tools.
+- `qveris`: tools covered by the Qveris adapter's Discover/Inspect/Probe/Call
+  route, including historical prices, indexes, macro data, company data, news,
+  and CSI constituents.
+- `binance`: public crypto price tools.
+- `web`: public finance news.
+- `local`: local-only utilities such as `current_timestamp`.
+
+When a request carries one or more API credentials, only tools backed by those
+credential sources are advertised. Explicit request credentials take priority
+over server environment fallbacks, so a shared server-side token does not
+expand another tenant's visible tool set.
+
+When no credential is configured, only public and local tools are advertised.
+For example:
+
+- Qveris key only: Qveris-covered existing tools.
+- Tushare token only: Tushare-backed tools.
+- Both keys: the union of Tushare and Qveris-covered tools.
+
+Adding a new source requires updating its credential resolution in
+`src/config.ts`, mapping covered tools in `src/dispatch.ts`, and adding list
+and direct-call tests for the new credential combination.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-mcp",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-mcp",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.6.0",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-mcp",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Multi-source financial data MCP server with Tushare, optional Qveris routing, and Binance crypto data",
   "type": "module",
   "bin": {
@@ -11,10 +11,12 @@
   },
   "files": [
     "build",
-    "docs/cache-gateway.md"
+    "docs/cache-gateway.md",
+    "docs/tool-availability.md"
   ],
   "scripts": {
-    "build": "tsc && node -e \"for(const f of ['build/index.js','build/httpServer.js','build/cacheGateway.js','build/cacheCli.js']){try{require('fs').chmodSync(f,'755')}catch(e){}}\"",
+    "clean": "node -e \"require('fs').rmSync('build',{recursive:true,force:true})\"",
+    "build": "npm run clean && tsc && node -e \"for(const f of ['build/index.js','build/httpServer.js','build/cacheGateway.js','build/cacheCli.js']){try{require('fs').chmodSync(f,'755')}catch(e){}}\"",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -2,7 +2,7 @@
 # 参考文档：https://smithery.ai/docs/build/project-config/smithery.yaml
 
 name: "@guangxiangdebizi/FinanceMCP"        # 服务器唯一标识
-version: "4.4.0"                             # 版本号
+version: "4.10.0"                             # 版本号
 description: "财经数据查询 & 财经新闻 & 公司财务表现分析 MCP"
 author:
   name: "Xingyu_Chen"

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,26 @@ export function getRequestToken(): string | undefined {
   return requestContext.getStore()?.tushareToken;
 }
 
+export type CredentialSource = Extract<DataSourceId, 'tushare' | 'qveris'>;
+
+/**
+ * Resolve credential-backed sources for the current request. Explicit request
+ * credentials take precedence over process-level fallbacks, which keeps a
+ * shared server credential from expanding another tenant's visible tools.
+ */
+export function getConfiguredCredentialSources(): CredentialSource[] {
+  const context = requestContext.getStore();
+  const requestSources: CredentialSource[] = [];
+  if (context?.tushareToken?.trim()) requestSources.push('tushare');
+  if (context?.qverisApiKey?.trim()) requestSources.push('qveris');
+  if (requestSources.length > 0) return requestSources;
+
+  const configuredSources: CredentialSource[] = [];
+  if (process.env.TUSHARE_TOKEN?.trim()) configuredSources.push('tushare');
+  if (process.env.QVERIS_API_KEY?.trim()) configuredSources.push('qveris');
+  return configuredSources;
+}
+
 export function getCoinGeckoApiKey(): string | undefined {
   return requestContext.getStore()?.coingeckoApiKey ?? process.env.COINGECKO_API_KEY ?? undefined;
 }

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -18,6 +18,7 @@ import { dragonTigerInst } from './tools/dragonTigerInst.js';
 import { hotNews } from './tools/hotNews.js';
 import { futuresData } from './tools/futuresData.js';
 import { routeToolCall } from './utils/dataSourceRouter.js';
+import { isToolSourceAvailable, ToolSource } from './toolAvailability.js';
 
 export const toolList = [
   { name: timestampTool.name, description: timestampTool.description, inputSchema: timestampTool.parameters },
@@ -40,6 +41,53 @@ export const toolList = [
   { name: hotNews.name, description: hotNews.description, inputSchema: hotNews.parameters },
   { name: futuresData.name, description: futuresData.description, inputSchema: futuresData.parameters },
 ];
+
+// Keep this mapping explicit: it is the contract used by tools/list and by the
+// direct-call guard. Qveris coverage mirrors getQverisToolPlan in qverisAdapter.
+const TOOL_SOURCES: Record<string, readonly ToolSource[]> = {
+  current_timestamp: ['local'],
+  finance_news: ['qveris', 'web'],
+  stock_data: ['tushare', 'qveris', 'binance'],
+  stock_data_minutes: ['tushare', 'qveris', 'binance'],
+  index_data: ['tushare', 'qveris'],
+  macro_econ: ['tushare', 'qveris'],
+  company_performance: ['tushare', 'qveris'],
+  fund_data: ['tushare'],
+  fund_manager_by_name: ['tushare'],
+  convertible_bond: ['tushare'],
+  block_trade: ['tushare'],
+  money_flow: ['tushare'],
+  margin_trade: ['tushare'],
+  company_performance_hk: ['tushare', 'qveris'],
+  company_performance_us: ['tushare', 'qveris'],
+  csi_index_constituents: ['tushare', 'qveris'],
+  dragon_tiger_inst: ['tushare'],
+  hot_news_7x24: ['tushare', 'qveris'],
+  futures_data: ['tushare'],
+};
+
+function toolSources(name: string): readonly ToolSource[] {
+  // New tools default to a credential-backed source until explicitly mapped.
+  return TOOL_SOURCES[name] ?? ['tushare'];
+}
+
+export function isToolAvailable(name: string): boolean {
+  return toolList.some(tool => tool.name === name)
+    && isToolSourceAvailable(toolSources(name));
+}
+
+export function getAvailableToolList() {
+  return toolList.filter(tool => isToolSourceAvailable(toolSources(tool.name)));
+}
+
+export function assertToolAvailable(name: string): void {
+  if (!toolList.some(tool => tool.name === name)) {
+    throw new Error(`Unknown tool: ${name}`);
+  }
+  if (!isToolAvailable(name)) {
+    throw new Error(`Tool ${name} is not available for the configured API credentials`);
+  }
+}
 
 async function dispatchNativeTool(name: string, args: Record<string, any>): Promise<any> {
   switch (name) {
@@ -175,8 +223,6 @@ async function dispatchNativeTool(name: string, args: Record<string, any>): Prom
 }
 
 export async function dispatchTool(name: string, args: Record<string, any>): Promise<any> {
-  if (!toolList.some(tool => tool.name === name)) {
-    throw new Error(`Unknown tool: ${name}`);
-  }
+  assertToolAvailable(name);
   return routeToolCall(name, args, () => dispatchNativeTool(name, args));
 }

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -3,7 +3,7 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import { randomUUID } from "node:crypto";
 import { parseSourcePriority, runWithRequestContext } from "./config.js";
-import { toolList, dispatchTool } from "./dispatch.js";
+import { getAvailableToolList, dispatchTool } from "./dispatch.js";
 
 
 interface Session { id: string; createdAt: Date; lastActivity: Date }
@@ -207,12 +207,20 @@ app.post('/mcp', async (req: Request, res: Response) => {
     sessions.set(newId, { id: newId, createdAt: new Date(), lastActivity: new Date() });
     res.setHeader('Mcp-Session-Id', newId);
     console.log(`✅ [MCP-initialize] New session created: ${newId}`);
-    return res.json({ jsonrpc: '2.0', result: { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'FinanceMCP', version: '4.9.0' } }, id: body.id });
+    return res.json({ jsonrpc: '2.0', result: { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'FinanceMCP', version: '4.10.0' } }, id: body.id });
   }
 
   if (method === 'tools/list') {
-    console.log(`📋 [MCP-tools/list] Returning ${toolList.length} tools`);
-    return res.json({ jsonrpc: '2.0', result: { tools: toolList }, id: body.id });
+    const token = extractTokenFromHeaders(req);
+    const qverisApiKey = extractQverisApiKeyFromHeaders(req);
+    const sourcePriority = extractSourcePriorityFromHeaders(req);
+    const availableTools = await runWithRequestContext({
+      tushareToken: token,
+      qverisApiKey,
+      sourcePriority,
+    }, async () => getAvailableToolList());
+    console.log(`📋 [MCP-tools/list] Returning ${availableTools.length} tools`);
+    return res.json({ jsonrpc: '2.0', result: { tools: availableTools }, id: body.id });
   }
 
   // 明确表示不支持 resources 和 prompts（返回空列表而不是错误）
@@ -289,7 +297,7 @@ app.listen(PORT, () => {
   console.log(`📡 MCP Endpoint:  http://localhost:${PORT}/mcp`);
   console.log(`💚 Health Check:  http://localhost:${PORT}/health`);
   console.log(`📊 Active Sessions: ${sessions.size}`);
-  console.log(`🔧 Available Tools: ${toolList.length}`);
+  console.log(`🔧 Available Tools: ${getAvailableToolList().length}`);
   console.log('='.repeat(60));
   console.log('📝 Server is ready to accept connections');
   console.log('='.repeat(60) + '\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,15 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
-import { toolList, dispatchTool } from "./dispatch.js";
+import { getAvailableToolList, dispatchTool } from "./dispatch.js";
 
 const server = new Server(
-  { name: "FinanceMCP", version: "4.9.0" },
+  { name: "FinanceMCP", version: "4.10.0" },
   { capabilities: { tools: {} } }
 );
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return { tools: toolList };
+  return { tools: getAvailableToolList() };
 });
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {

--- a/src/toolAvailability.ts
+++ b/src/toolAvailability.ts
@@ -1,0 +1,18 @@
+import { DataSourceId, getConfiguredCredentialSources } from './config.js';
+
+export type ToolSource = DataSourceId | 'web' | 'local';
+
+/**
+ * With no credentials, only public/local capabilities are advertised. Once a
+ * credential scope exists, the visible set is limited to that scope.
+ */
+export function getActiveToolSources(): Set<ToolSource> {
+  const credentialSources = getConfiguredCredentialSources();
+  if (credentialSources.length > 0) return new Set(credentialSources);
+  return new Set<ToolSource>(['binance', 'web', 'local']);
+}
+
+export function isToolSourceAvailable(requiredSources: readonly ToolSource[]): boolean {
+  const activeSources = getActiveToolSources();
+  return requiredSources.some(source => activeSources.has(source));
+}

--- a/test/tool-availability.test.mjs
+++ b/test/tool-availability.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import test from 'node:test';
+
+import { runWithRequestContext } from '../build/config.js';
+import { dispatchTool, getAvailableToolList } from '../build/dispatch.js';
+
+function names(tools) {
+  return tools.map(tool => tool.name);
+}
+
+async function reservePort() {
+  const server = http.createServer();
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const port = address.port;
+  await new Promise(resolve => server.close(resolve));
+  return port;
+}
+
+async function waitForHealth(port) {
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      if (response.ok) return;
+    } catch {}
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error('HTTP test server did not become healthy');
+}
+
+test('Qveris-only requests advertise the adapter-covered tools', async () => {
+  const tools = await runWithRequestContext({ qverisApiKey: 'qveris-test-key' }, async () => {
+    return getAvailableToolList();
+  });
+  assert.deepEqual(names(tools), [
+    'finance_news',
+    'stock_data',
+    'stock_data_minutes',
+    'index_data',
+    'macro_econ',
+    'company_performance',
+    'company_performance_hk',
+    'company_performance_us',
+    'csi_index_constituents',
+    'hot_news_7x24',
+  ]);
+});
+
+test('Tushare-only requests exclude Qveris-only and public-only tools', async () => {
+  const tools = await runWithRequestContext({ tushareToken: 'tushare-test-token' }, async () => {
+    return getAvailableToolList();
+  });
+  const available = names(tools);
+  assert.equal(available.length, 17);
+  assert.ok(available.includes('stock_data'));
+  assert.ok(available.includes('fund_data'));
+  assert.equal(available.includes('finance_news'), false);
+  assert.equal(available.includes('current_timestamp'), false);
+});
+
+test('both credentials expose the union while keeping local-only tools scoped', async () => {
+  const tools = await runWithRequestContext({
+    tushareToken: 'tushare-test-token',
+    qverisApiKey: 'qveris-test-key',
+  }, async () => getAvailableToolList());
+  const available = names(tools);
+  assert.equal(available.length, 18);
+  assert.ok(available.includes('finance_news'));
+  assert.ok(available.includes('fund_data'));
+  assert.equal(available.includes('current_timestamp'), false);
+});
+
+test('direct calls cannot bypass the filtered tool list', async () => {
+  await assert.rejects(
+    () => runWithRequestContext({ qverisApiKey: 'qveris-test-key' }, async () => {
+      return dispatchTool('fund_data', { data_type: 'basic' });
+    }),
+    /not available for the configured API credentials/,
+  );
+});
+
+test('HTTP tools/list applies the request credential scope', async () => {
+  const port = await reservePort();
+  const child = spawn(process.execPath, ['build/httpServer.js'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      PORT: String(port),
+      TUSHARE_TOKEN: '',
+      QVERIS_API_KEY: '',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  try {
+    await waitForHealth(port);
+    const list = async headers => {
+      const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      });
+      assert.equal(response.status, 200);
+      return response.json();
+    };
+
+    const qveris = await list({ 'X-Qveris-Api-Key': 'qveris-http-test-key' });
+    const tushare = await list({ 'X-Tushare-Token': 'tushare-http-test-token' });
+    assert.equal(qveris.result.tools.length, 10);
+    assert.equal(tushare.result.tools.length, 17);
+    assert.equal(tushare.result.tools.some(tool => tool.name === 'finance_news'), false);
+  } finally {
+    child.kill();
+    await Promise.race([
+      new Promise(resolve => child.once('exit', resolve)),
+      new Promise(resolve => setTimeout(resolve, 5000)),
+    ]);
+  }
+});


### PR DESCRIPTION
## Summary\n- Filter 	ools/list by credentials present on the current MCP request.\n- Qveris-only requests expose only the existing tools covered by qverisAdapter; Tushare-only requests expose Tushare-backed tools.\n- Enforce the same source scope before 	ools/call.\n- Add HTTP/stdio coverage tests and credential-scoped documentation.\n- Bump package/server/Smithery metadata to 4.10.0 and clean stale build output before packaging.\n\n## Verification\n- 
pm test (22 tests passed)\n- HTTP smoke: Qveris-only returns 10 tools; Tushare-only returns 17 tools.\n- 
pm pack --dry-run: package inance-mcp@4.10.0, tool availability docs included.\n- git diff --check clean.\n\n## Security note\n- 
pm audit --omit=dev reports the existing direct @modelcontextprotocol/sdk 0.6.0 DNS-rebinding advisory; remediation requires a major SDK upgrade and is intentionally kept as a separate compatibility task.\n\n## Review scope\n- Based on the latest main (includes Qveris routing and cache gateway); no duplicate feature code is included.